### PR TITLE
compiling the vignette requires a preexisting ivis virtual environment

### DIFF
--- a/R-package/README.md
+++ b/R-package/README.md
@@ -1,18 +1,18 @@
 # R wrapper for the IVIS algorithm
 
+# Installation {#installation-basic}
 
-## Installation
-R wrapper for `ivis` is provided via the `reticulate` library. Prior to installation, ensure that `reticulate` is available on your machine.
+R wrapper for `ivis` is provided via the `reticulate` library.
+Prior to installation, ensure that `reticulate` is available on your machine.
 
 ```R
 install.packages("reticulate")
 ```
 
-
 The easiest way to install `ivis` is using the `devtools` package:
 
 ```R
-devtools::install_github("beringresearch/ivis/R-package", build_vignettes = TRUE)
+devtools::install_github("beringresearch/ivis/R-package")
 library(ivis)
 install_ivis()
 ```
@@ -51,4 +51,17 @@ dat <- data.frame(x=xy[,1],
 ggplot(dat, aes(x=x, y=y)) +
   geom_point(aes(color=species)) +
   theme_classic()
+```
+
+## Vignette {#installation-vignette}
+
+The `ivis` package includes a [vignette](https://github.com/beringresearch/ivis/blob/master/R-package/vignettes/ivis_singlecell.Rmd) that demonstrates an example workflow using single-cell RNA-sequencing data.
+
+To compile and install this vignette on your system, you need to first have a working installation of `ivis`.
+For this, please follow the instructions [above](#installation-basic).
+
+Once you have a working installation of `ivis`, you can reinstall the package including the compiled vignette using the following command:
+
+```R
+devtools::install_github("beringresearch/ivis/R-package", build_vignettes = TRUE, force=TRUE)
 ```


### PR DESCRIPTION
As the vignette itself does not run the `install_ivis()` function, this PR clarifies the README as follows: the user needs to first install the package without the vignette, then run `install_ivis()` themselves to create the virtual environment, and restart their R session before they can finally compile the vignette as part of the installation procedure.

To demonstrate the issue, the following code chunk shows what happens if the "ivis" virtual environment does not exist yet when users try to compile the vignette during the installation (i.e. this basically simulates what would happen for users who would try to compile the vignette as part of their first ever installation of `ivis`).
```
> reticulate::virtualenv_remove("ivis")
> devtools::install_github("beringresearch/ivis/R-package", build_vignettes = TRUE)
Downloading GitHub repo beringresearch/ivis@master
   checking for file ‘/private/var/folders/cp/8rn2cs_x79zcbp_yb75ychg80000gq/T/RtmpMCmYdS/remotesb9fe415c0ccc/beringresearch-ivis-853aad0/R-package/DESCRIPTION’✔  checking for file ‘/private/var/folders/cp/8rn2cs_x79zcbp_yb75ychg80000gq/T/RtmpMCmYdS/remotesb9fe415c0ccc/beringresearch-ivis-853aad0/R-package/DESCRIPTION’
─  preparing ‘ivis’:
✔  checking DESCRIPTION meta-information ...
─  installing the package to build vignettes
E  creating vignettes (56.5s)
   --- re-building ‘ivis_singlecell.Rmd’ using rmarkdown

[... output of the first few code chunks...]

   Quitting from lines 80-93 (ivis_singlecell.Rmd) 
   Error: processing vignette 'ivis_singlecell.Rmd' failed with diagnostics:
   attempt to apply non-function
   --- failed re-building ‘ivis_singlecell.Rmd’
   
   SUMMARY: processing the following file failed:
     ‘ivis_singlecell.Rmd’
   
   Error: Vignette re-building failed.
   Execution halted
Error: Failed to install 'ivis' from GitHub:
  System command error, exit status: 1, stderr empty
```