### PR TITLE
Modifications to ensure adherence to sklearn API

### DIFF
--- a/ivis/ivis.py
+++ b/ivis/ivis.py
@@ -13,7 +13,7 @@ from tensorflow.keras.callbacks import EarlyStopping
 from tensorflow.keras.models import load_model, Model
 from tensorflow.keras.layers import Dense, Input
 from tensorflow.keras import regularizers
-from sklearn.base import BaseEstimator
+from sklearn.base import BaseEstimator, TransformerMixin
 
 
 from .data.generators import generator_from_neighbour_matrix, KerasSequence
@@ -25,12 +25,12 @@ from .data.neighbour_retrieval import AnnoyKnnMatrix
 from .data.neighbour_retrieval.knn import cleanup_knn_index
 
 
-class Ivis(BaseEstimator):
+class Ivis(BaseEstimator, TransformerMixin):
     """Ivis is a technique that uses an artificial neural network for
     dimensionality reduction, often useful for the purposes of visualization.
     The network trains on triplets of data-points at a time and pulls positive
     points together, while pushing more distant points away from each other.
-    Triplets are sampled from the original data using KNN aproximation using
+    Triplets are sampled from the original data using KNN approximation using
     the Annoy library.
 
     :param int embedding_dims: Number of dimensions in the embedding space
@@ -144,18 +144,20 @@ class Ivis(BaseEstimator):
         self.supervised_model_ = None
         self.loss_history_ = []
         self.annoy_index_path = annoy_index_path
-
-        if callbacks is None:
-            self.callbacks = []
-        else:
-            self.callbacks = callbacks
-        for callback in self.callbacks:
-            if isinstance(callback, ModelCheckpoint):
-                callback = callback.register_ivis_model(self)
+        self.callbacks = callbacks
+        self.callbacks_ = None
         self.build_index_on_disk = build_index_on_disk
         self.neighbour_matrix = neighbour_matrix
         self.verbose = verbose
         self.n_classes = None
+
+    def _validate_parameters(self):
+        """ Validate parameters before fitting """
+        self.callbacks_ = [] if self.callbacks is None else self.callbacks
+
+        for callback in self.callbacks_:
+            if isinstance(callback, ModelCheckpoint):
+                callback.register_ivis_model(self)
 
     def __getstate__(self):
         """ Return object serializable variable dict """
@@ -178,6 +180,8 @@ class Ivis(BaseEstimator):
         return state
 
     def _fit(self, X, Y=None, shuffle_mode=True):
+        self._validate_parameters()
+
         if self.neighbour_matrix is None:
             if self.annoy_index_path is None:
                 # Create a temporary folder to store the index on disk
@@ -296,8 +300,8 @@ class Ivis(BaseEstimator):
         hist = self.model_.fit(
             datagen,
             epochs=self.epochs,
-            callbacks=self.callbacks + [EarlyStopping(monitor=loss_monitor,
-                                                      patience=self.n_epochs_without_progress)],
+            callbacks=self.callbacks_ + [EarlyStopping(monitor=loss_monitor,
+                                                       patience=self.n_epochs_without_progress)],
             shuffle=shuffle_mode,
             steps_per_epoch=int(np.ceil(X.shape[0] / self.batch_size)),
             verbose=self.verbose)
@@ -333,7 +337,7 @@ class Ivis(BaseEstimator):
             Data to train on and then embedded.
             Needs to have a `.shape` attribute and a `__getitem__` method.
         Y : array, shape (n_samples)
-            Optional array for supervised dimentionality reduction.
+            Optional array for supervised dimensionality reduction.
             If Y contains -1 labels, and 'sparse_categorical_crossentropy'
             is the loss function, semi-supervised learning will be used.
 


### PR DESCRIPTION
# The issues
On `ivis.Ivis.__init__()`, some logic is present to handle the `callbacks` parameter. This resulted in a parameter change upon initialization of the transformer which might cause errors when using certain `sklearn` tools (e.g., `sklearn.base.clone()`). Moreover, the `sklearn.base.TransformerMixin` mixin was not inherited by `Ivis` despite the presence of `ivis.Ivis.transform()`.

# Minimal reproducible example
## Environment
A virtual environment was created specifically for this project, wherein all modules described in `requirements.txt` were installed. My setup runs an up-to-date version of Windows 10 (no WSL).

### Runtime
```
python=3.8.4
```

### Relevant modules
```
ivis=2.0.3
tensorflow=2.5.0
```

## Code (executed in interpreter)
```
>>> import ivis
>>> ivis.Ivis()  # Expected to see `Ivis()`, but that is not the case, as `Ivis.callbacks` is changed in `Ivis.__init__()`.
Ivis(callbacks=[])
```

# The proposed changes
According to [the sklearn documentation on developing a custom estimator](), in the constructor,

> there should be no logic, not even input validation, and the parameters should not be changed. The corresponding logic should be put where the parameters are used, typically in fit.

To ensure a greater adherence to the `sklearn` API, any logic present in the constructor should be moved elsewhere. One strategy, which I implemented herein and submit to your scrutiny, is to create a method dedicated to validating the parameters (`Ivis._validate_parameters()`).

Since `Ivis` is a transformer, I believe its inheritance of `sklearn.base.TransformerMixin` is pertinent as well, unless there is some motivation behind not inheriting `TransformerMixin` that I could not find.