### PR TITLE
More modifications to ensure adherence to the sklearn API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@ __pycache__/
 .ipynb_checkpoints
 _build
 *.pyc
+venv
+.idea

--- a/ivis/ivis.py
+++ b/ivis/ivis.py
@@ -130,7 +130,7 @@ class Ivis(BaseEstimator, TransformerMixin):
         self.epochs = epochs
         self.n_epochs_without_progress = n_epochs_without_progress
         self.knn_distance_metric = knn_distance_metric
-        self.n_trees = ntrees or n_trees
+        self.n_trees = n_trees
         self.ntrees = ntrees
         self.search_k = search_k
         self.precompute = precompute
@@ -151,8 +151,6 @@ class Ivis(BaseEstimator, TransformerMixin):
         self.neighbour_matrix_ = None
         self.supervised_model_ = None
 
-        deprecation.check_deprecated_ntrees(ntrees)
-
     def _validate_parameters(self):
         """ Validate parameters before fitting """
         self.callbacks_ = [] if self.callbacks is None else list(map(copy, self.callbacks))
@@ -161,6 +159,12 @@ class Ivis(BaseEstimator, TransformerMixin):
         for callback in self.callbacks_:
             if isinstance(callback, ModelCheckpoint):
                 callback.register_ivis_model(self)
+
+        if self.ntrees is not None:
+            deprecation.check_deprecated_ntrees(self.ntrees)
+
+            self.n_trees = self.ntrees
+            self.ntrees = None
 
     def __getstate__(self):
         """ Return object serializable variable dict """

--- a/ivis/ivis.py
+++ b/ivis/ivis.py
@@ -131,6 +131,7 @@ class Ivis(BaseEstimator, TransformerMixin):
         self.n_epochs_without_progress = n_epochs_without_progress
         self.knn_distance_metric = knn_distance_metric
         self.n_trees = ntrees or n_trees
+        self.ntrees = ntrees
         self.search_k = search_k
         self.precompute = precompute
         self.model = model

--- a/ivis/ivis.py
+++ b/ivis/ivis.py
@@ -4,11 +4,12 @@ import json
 import os
 import shutil
 import tempfile
+
+from copy import copy
+
 import dill as pkl
 import tensorflow as tf
 import numpy as np
-
-from copy import copy
 
 from tensorflow import keras
 from tensorflow.keras.callbacks import EarlyStopping

--- a/ivis/utils/deprecation.py
+++ b/ivis/utils/deprecation.py
@@ -6,5 +6,5 @@ def check_deprecated_ntrees(ntrees):
     if ntrees is not None:
         warnings.warn("Received a value for `ntrees`. In the future, passing "
                       "a value to `ntrees` will result in a ValueError. "
-                      "`n_trees` was set to `ntrees`. Use `n_trees` "
+                      f"`n_trees` was set to `{ntrees}`. Use `n_trees` "
                       "instead.", FutureWarning)

--- a/ivis/utils/deprecation.py
+++ b/ivis/utils/deprecation.py
@@ -5,5 +5,5 @@ def check_deprecated_ntrees(ntrees):
     if ntrees is not None:
         warnings.warn("Received a value for `ntrees`. In the future, passing "
                       "a value to `ntrees` will result in a ValueError. "
-                      "`n_trees` was set to `ntrees`. In the future, use "
-                      "`n_trees` instead.", FutureWarning)
+                      "`n_trees` was set to `ntrees`. Use `n_trees` "
+                      "instead.", FutureWarning)

--- a/ivis/utils/deprecation.py
+++ b/ivis/utils/deprecation.py
@@ -2,6 +2,7 @@ import warnings
 
 
 def check_deprecated_ntrees(ntrees):
+    """ Checks for the use of ntrees """
     if ntrees is not None:
         warnings.warn("Received a value for `ntrees`. In the future, passing "
                       "a value to `ntrees` will result in a ValueError. "

--- a/ivis/utils/deprecation.py
+++ b/ivis/utils/deprecation.py
@@ -1,0 +1,9 @@
+import warnings
+
+
+def check_deprecated_ntrees(ntrees):
+    if ntrees is not None:
+        warnings.warn("Received a value for `ntrees`. In the future, passing "
+                      "a value to `ntrees` will result in a ValueError. "
+                      "`n_trees` was set to `ntrees`. In the future, use "
+                      "`n_trees` instead.", FutureWarning)

--- a/tests/test_model_saving.py
+++ b/tests/test_model_saving.py
@@ -30,8 +30,8 @@ def test_ivis_model_saving(model_filepath):
     assert model.__getstate__() == model_2.__getstate__()
 
     # Check all weights are the same
-    for model_layer, model_2_layer in zip(model.encoder.layers,
-                                          model_2.encoder.layers):
+    for model_layer, model_2_layer in zip(model.encoder_.layers,
+                                          model_2.encoder_.layers):
         model_layer_weights = model_layer.get_weights()
         model_2_layer_weights = model_2_layer.get_weights()
         for i in range(len(model_layer_weights)):
@@ -74,8 +74,8 @@ def test_supervised_model_saving(model_filepath):
     assert model.__getstate__() == model_2.__getstate__()
 
     # Check all weights are the same
-    for model_layer, model_2_layer in zip(model.encoder.layers,
-                                          model_2.encoder.layers):
+    for model_layer, model_2_layer in zip(model.encoder_.layers,
+                                          model_2.encoder_.layers):
         model_layer_weights = model_layer.get_weights()
         model_2_layer_weights = model_2_layer.get_weights()
         for i in range(len(model_layer_weights)):
@@ -125,8 +125,8 @@ def test_custom_model_saving(model_filepath):
     assert model.__getstate__() == model_2.__getstate__()
 
     # Check all weights are the same
-    for model_layer, model_2_layer in zip(model.encoder.layers,
-                                          model_2.encoder.layers):
+    for model_layer, model_2_layer in zip(model.encoder_.layers,
+                                          model_2.encoder_.layers):
         model_layer_weights = model_layer.get_weights()
         model_2_layer_weights = model_2_layer.get_weights()
         for i in range(len(model_layer_weights)):


### PR DESCRIPTION
# The issues

- `Ivis.fit()` changes the value of `Ivis.neighbour_matrix`; and
- `Ivis.encoder` is defined without a trailing underscore.

# Minimal reproducible example

## Environment

A virtual environment was created specifically for this project, wherein all modules specified in `requirements.txt` were installed. My setup runs an up-to-date version of Windows 10 (no WSL).

### Runtime

```
python=3.9.5
```

### Relevant modules

```
ivis=2.0.4
tensorflow=2.5.0
```

## Code (executed in interpreter)

```
>>> import ivis
...
... from sklearn import datasets
...
...
... X, y = datasets.load_iris(return_X_y=True)
... model = ivis.Ivis(k=15, verbose=0)
>>> model
Ivis(k=15, verbose=0)
>>> model.encoder  # Expected to see an AttributeError, as this parameter should not exist, but this is not the case as
...                # `Ivis.encoder` is defined in `Ivis.__init__()` as `None`.

>>> model.fit(X)  # Expected to see the same result seen above, but this is not the case as `Ivis.neighbour_matrix` is
...               # changed from its default value in `Ivis.fit()`.
Ivis(k=15,
     neighbour_matrix=<ivis.data.neighbour_retrieval.knn.AnnoyKnnMatrix object at 0x00000201CF622C10>,
     verbose=0)
```

# The proposed changes

Similarly to #95, I will quote parts of [the sklearn documentation on custom estimator development guidelines](https://scikit-learn.org/stable/developers/develop.html):

> There should be no logic, not even input validation, and the parameters should not be changed. The corresponding logic should be put where the parameters are used, typically in `fit`.

> Attributes that have been estimated from the data must always have a name ending with trailing underscore, for example the coefficients of some regression estimator would be stored in a `coef_` attribute after `fit` has been called.

The issue involving the change of `neighbour_matrix` after `Ivis.fit()` is called breaks the first assumption, whereas defining `encoder` without the trailing underscore in `Ivis.__init__()` breaks the second one.

To solve the first issue, a new parameter called `neighbour_matrix_` was created, following what was done with `callbacks` and `callbacks_` for instance. Additionally, `neighbour_matrix_` was programmed to receive the value of `neighbour_matrix` in `Ivis._validate_parameters()`, and all references to `neighbour_matrix_` in `Ivis.fit()` were changed to `neighbour_matrix_`.

To solve the second issue, `encoder` was globally renamed to `encoder_`.

Minor changes were performed in this pull request as well, which I leave alongside the aforementioned changes for your scrutiny:

- `ntrees` was renamed to `n_trees` (for purely stylistical and debatable reasons, so feel free to disagree);
- the `venv` and `.idea` folders were added to `.gitignore` (so that PyCharm IDE files and any virtual environments are not tracked by `git`); and
- other minor modifications.