### PR TITLE
Make `ivis.Ivis` picklable

### DIFF
--- a/ivis/data/neighbour_retrieval/knn.py
+++ b/ivis/data/neighbour_retrieval/knn.py
@@ -15,11 +15,13 @@ import numpy as np
 
 from ..data import get_uint_ctype
 
+
 class NeighbourMatrix(Sequence):
     r"""A matrix A\ :subscript:`ij` where i is the row index of the data point and j
     refers to the index of the neigbouring point.
 
     """
+
     @property
     @abstractmethod
     def k(self):
@@ -31,6 +33,7 @@ class NeighbourMatrix(Sequence):
 
         Non-optimized version, can be overridden by child classes to be made be efficient"""
         return [self.__getitem__(item) for item in idx_seq]
+
 
 class AnnoyKnnMatrix(NeighbourMatrix):
     r"""Neighbouring points are KNN retrieved using an Annoy Index.
@@ -163,13 +166,15 @@ class AnnoyKnnMatrix(NeighbourMatrix):
         self.index.unload()
         shutil.rmtree(path)
 
+
 def _validate_knn_shape(nrows, k):
     if k <= 0:
-        raise ValueError('Invalid value of `%s` for k. k must be positive' %k)
+        raise ValueError('Invalid value of `%s` for k. k must be positive' % k)
     if k >= nrows:
         raise ValueError('''k value greater than or equal to num_rows
                             (k={}, rows={}). Lower k to a smaller
                             value.'''.format(k, nrows))
+
 
 def build_annoy_index(X, path, metric='angular', ntrees=50, build_index_on_disk=True,
                       verbose=1, n_jobs=-1):
@@ -239,6 +244,7 @@ def build_annoy_index(X, path, metric='angular', ntrees=50, build_index_on_disk=
         index.save(path)
     return index
 
+
 def extract_knn(knn_index, verbose=1, n_jobs=-1):
     """Starts multiple threads to retrieve nearest neighbours from a built index in parallel.
 
@@ -258,6 +264,7 @@ def extract_knn(knn_index, verbose=1, n_jobs=-1):
                           "Set `precompute` to False or reduce the value for `k`.") from err
 
     worker_exception = None  # Halt signal
+
     def knn_worker(thread_index, data_indices):
         nonlocal worker_exception
         for i in range(data_indices[0], data_indices[1]):


### PR DESCRIPTION
# The issue

See #101.

# The proposed changes

This pull request refactors `Ivis.__getstate__()` into `Ivis.__getstate_old__()` and creates new `Ivis.__getstate__()` and `Ivis.__setstate__()` methods. They work similarly to what is seen in `Ivis.save_model()` and `Ivis.load_model()` in terms of the information that is saved; however, they differ in how they do it. The new methods encode the generated files into `base85` strings and save said strings within the object—in other words, the generated files are effectively saved within the object.

This approach comes with the following advantages:

- It makes `Ivis` picklable, thus enabling the storage of a produced model under a single file written in a well-known format within the Python community.
- It solves #101 and increases compatibility with the `scikit-learn` module, particularly with `sklearn.model_selection.GridSearchCV` and `sklearn.base.clone()`, which is used within `sklearn.model_selection.GridSearchCV` and `sklearn.pipeline.Pipeline`.

The only caveat is the same one seen when using the existing `Ivis.save_model()` and `Ivis.load_model()`: whenever a `tensorflow`/`keras` model is saved by using the `.save()` method, the following warning is issued:

```
WARNING:tensorflow:Compiled the loaded model, but the compiled metrics have yet to be built. `model.compile_metrics` will be empty until you train or evaluate the model.
```

This warning is issued two times per save/load call (when `Ivis.model_.layers[3]` and `Ivis.supervised_model_` are saved/loaded), which means in circumstances wherein these commands are frequently used result this message being spammed throughout the execution, as demonstrated below.

# Minimal reproducible examples

The environment used in these examples is the same described in #101.

## Example with `sklearn.pipeline.Pipeline`

The same code seen in #101 is executed. The execution is successful, but the log is polluted by compilation warnings related with the aforementioned issue.

```
Fitting 10 folds for each of 2 candidates, totalling 20 fits
WARNING:tensorflow:Compiled the loaded model, but the compiled metrics have yet to be built. `model.compile_metrics` will be empty until you train or evaluate the model.
WARNING:tensorflow:Compiled the loaded model, but the compiled metrics have yet to be built. `model.compile_metrics` will be empty until you train or evaluate the model.
WARNING:tensorflow:Compiled the loaded model, but the compiled metrics have yet to be built. `model.compile_metrics` will be empty until you train or evaluate the model.
WARNING:tensorflow:Compiled the loaded model, but the compiled metrics have yet to be built. `model.compile_metrics` will be empty until you train or evaluate the model.
[CV 1/10] END classify=RandomForestClassifier(), classify__random_state=2021, project=Ivis(verbose=0), project__k=15;, score=(train=1.000, test=1.000) total time=   6.2s
WARNING:tensorflow:Compiled the loaded model, but the compiled metrics have yet to be built. `model.compile_metrics` will be empty until you train or evaluate the model.
WARNING:tensorflow:Compiled the loaded model, but the compiled metrics have yet to be built. `model.compile_metrics` will be empty until you train or evaluate the model.
WARNING:tensorflow:Compiled the loaded model, but the compiled metrics have yet to be built. `model.compile_metrics` will be empty until you train or evaluate the model.
WARNING:tensorflow:Compiled the loaded model, but the compiled metrics have yet to be built. `model.compile_metrics` will be empty until you train or evaluate the model.
[CV 2/10] END classify=RandomForestClassifier(), classify__random_state=2021, project=Ivis(verbose=0), project__k=15;, score=(train=1.000, test=1.000) total time=   4.0s
WARNING:tensorflow:Compiled the loaded model, but the compiled metrics have yet to be built. `model.compile_metrics` will be empty until you train or evaluate the model.
WARNING:tensorflow:Compiled the loaded model, but the compiled metrics have yet to be built. `model.compile_metrics` will be empty until you train or evaluate the model.
WARNING:tensorflow:Compiled the loaded model, but the compiled metrics have yet to be built. `model.compile_metrics` will be empty until you train or evaluate the model.
WARNING:tensorflow:Compiled the loaded model, but the compiled metrics have yet to be built. `model.compile_metrics` will be empty until you train or evaluate the model.
[CV 3/10] END classify=RandomForestClassifier(), classify__random_state=2021, project=Ivis(verbose=0), project__k=15;, score=(train=1.000, test=0.933) total time=   8.0s
WARNING:tensorflow:Compiled the loaded model, but the compiled metrics have yet to be built. `model.compile_metrics` will be empty until you train or evaluate the model.
WARNING:tensorflow:Compiled the loaded model, but the compiled metrics have yet to be built. `model.compile_metrics` will be empty until you train or evaluate the model.
WARNING:tensorflow:Compiled the loaded model, but the compiled metrics have yet to be built. `model.compile_metrics` will be empty until you train or evaluate the model.
WARNING:tensorflow:Compiled the loaded model, but the compiled metrics have yet to be built. `model.compile_metrics` will be empty until you train or evaluate the model.
[CV 4/10] END classify=RandomForestClassifier(), classify__random_state=2021, project=Ivis(verbose=0), project__k=15;, score=(train=1.000, test=0.933) total time=   4.8s
WARNING:tensorflow:Compiled the loaded model, but the compiled metrics have yet to be built. `model.compile_metrics` will be empty until you train or evaluate the model.
WARNING:tensorflow:Compiled the loaded model, but the compiled metrics have yet to be built. `model.compile_metrics` will be empty until you train or evaluate the model.
WARNING:tensorflow:Compiled the loaded model, but the compiled metrics have yet to be built. `model.compile_metrics` will be empty until you train or evaluate the model.
WARNING:tensorflow:Compiled the loaded model, but the compiled metrics have yet to be built. `model.compile_metrics` will be empty until you train or evaluate the model.
[CV 5/10] END classify=RandomForestClassifier(), classify__random_state=2021, project=Ivis(verbose=0), project__k=15;, score=(train=1.000, test=0.733) total time=   6.3s
WARNING:tensorflow:Compiled the loaded model, but the compiled metrics have yet to be built. `model.compile_metrics` will be empty until you train or evaluate the model.
WARNING:tensorflow:Compiled the loaded model, but the compiled metrics have yet to be built. `model.compile_metrics` will be empty until you train or evaluate the model.
WARNING:tensorflow:Compiled the loaded model, but the compiled metrics have yet to be built. `model.compile_metrics` will be empty until you train or evaluate the model.
WARNING:tensorflow:Compiled the loaded model, but the compiled metrics have yet to be built. `model.compile_metrics` will be empty until you train or evaluate the model.
[CV 6/10] END classify=RandomForestClassifier(), classify__random_state=2021, project=Ivis(verbose=0), project__k=15;, score=(train=1.000, test=0.867) total time=   3.0s
WARNING:tensorflow:Compiled the loaded model, but the compiled metrics have yet to be built. `model.compile_metrics` will be empty until you train or evaluate the model.
WARNING:tensorflow:Compiled the loaded model, but the compiled metrics have yet to be built. `model.compile_metrics` will be empty until you train or evaluate the model.
WARNING:tensorflow:Compiled the loaded model, but the compiled metrics have yet to be built. `model.compile_metrics` will be empty until you train or evaluate the model.
WARNING:tensorflow:Compiled the loaded model, but the compiled metrics have yet to be built. `model.compile_metrics` will be empty until you train or evaluate the model.
[CV 7/10] END classify=RandomForestClassifier(), classify__random_state=2021, project=Ivis(verbose=0), project__k=15;, score=(train=1.000, test=1.000) total time=   2.8s
WARNING:tensorflow:Compiled the loaded model, but the compiled metrics have yet to be built. `model.compile_metrics` will be empty until you train or evaluate the model.
WARNING:tensorflow:Compiled the loaded model, but the compiled metrics have yet to be built. `model.compile_metrics` will be empty until you train or evaluate the model.
WARNING:tensorflow:Compiled the loaded model, but the compiled metrics have yet to be built. `model.compile_metrics` will be empty until you train or evaluate the model.
WARNING:tensorflow:Compiled the loaded model, but the compiled metrics have yet to be built. `model.compile_metrics` will be empty until you train or evaluate the model.
[CV 8/10] END classify=RandomForestClassifier(), classify__random_state=2021, project=Ivis(verbose=0), project__k=15;, score=(train=1.000, test=0.800) total time=   3.7s
WARNING:tensorflow:Compiled the loaded model, but the compiled metrics have yet to be built. `model.compile_metrics` will be empty until you train or evaluate the model.
WARNING:tensorflow:Compiled the loaded model, but the compiled metrics have yet to be built. `model.compile_metrics` will be empty until you train or evaluate the model.
WARNING:tensorflow:Compiled the loaded model, but the compiled metrics have yet to be built. `model.compile_metrics` will be empty until you train or evaluate the model.
WARNING:tensorflow:Compiled the loaded model, but the compiled metrics have yet to be built. `model.compile_metrics` will be empty until you train or evaluate the model.
[CV 9/10] END classify=RandomForestClassifier(), classify__random_state=2021, project=Ivis(verbose=0), project__k=15;, score=(train=1.000, test=0.733) total time=   3.8s
WARNING:tensorflow:Compiled the loaded model, but the compiled metrics have yet to be built. `model.compile_metrics` will be empty until you train or evaluate the model.
WARNING:tensorflow:Compiled the loaded model, but the compiled metrics have yet to be built. `model.compile_metrics` will be empty until you train or evaluate the model.
WARNING:tensorflow:Compiled the loaded model, but the compiled metrics have yet to be built. `model.compile_metrics` will be empty until you train or evaluate the model.
WARNING:tensorflow:Compiled the loaded model, but the compiled metrics have yet to be built. `model.compile_metrics` will be empty until you train or evaluate the model.
[CV 10/10] END classify=RandomForestClassifier(), classify__random_state=2021, project=Ivis(verbose=0), project__k=15;, score=(train=1.000, test=0.733) total time=   3.0s
WARNING:tensorflow:No training configuration found in the save file, so the model was *not* compiled. Compile it manually.
WARNING:tensorflow:No training configuration found in the save file, so the model was *not* compiled. Compile it manually.
[CV 1/10] END classify=SVC(), classify__random_state=2021, project=Ivis(verbose=0), project__k=15;, score=(train=0.948, test=1.000) total time=   0.5s
WARNING:tensorflow:No training configuration found in the save file, so the model was *not* compiled. Compile it manually.
WARNING:tensorflow:No training configuration found in the save file, so the model was *not* compiled. Compile it manually.
[CV 2/10] END classify=SVC(), classify__random_state=2021, project=Ivis(verbose=0), project__k=15;, score=(train=0.933, test=1.000) total time=   0.4s
WARNING:tensorflow:No training configuration found in the save file, so the model was *not* compiled. Compile it manually.
WARNING:tensorflow:No training configuration found in the save file, so the model was *not* compiled. Compile it manually.
[CV 3/10] END classify=SVC(), classify__random_state=2021, project=Ivis(verbose=0), project__k=15;, score=(train=0.941, test=1.000) total time=   0.4s
WARNING:tensorflow:No training configuration found in the save file, so the model was *not* compiled. Compile it manually.
WARNING:tensorflow:No training configuration found in the save file, so the model was *not* compiled. Compile it manually.
WARNING:tensorflow:5 out of the last 15 calls to <function Model.make_predict_function.<locals>.predict_function at 0x000002269499F4C0> triggered tf.function retracing. Tracing is expensive and the excessive number of tracings could be due to (1) creating @tf.function repeatedly in a loop, (2) passing tensors with different shapes, (3) passing Python objects instead of tensors. For (1), please define your @tf.function outside of the loop. For (2), @tf.function has experimental_relax_shapes=True option that relaxes argument shapes that can avoid unnecessary retracing. For (3), please refer to https://www.tensorflow.org/guide/function#controlling_retracing and https://www.tensorflow.org/api_docs/python/tf/function for  more details.
[CV 4/10] END classify=SVC(), classify__random_state=2021, project=Ivis(verbose=0), project__k=15;, score=(train=0.941, test=0.933) total time=   0.4s
WARNING:tensorflow:No training configuration found in the save file, so the model was *not* compiled. Compile it manually.
WARNING:tensorflow:No training configuration found in the save file, so the model was *not* compiled. Compile it manually.
WARNING:tensorflow:5 out of the last 13 calls to <function Model.make_predict_function.<locals>.predict_function at 0x0000022696CB5E50> triggered tf.function retracing. Tracing is expensive and the excessive number of tracings could be due to (1) creating @tf.function repeatedly in a loop, (2) passing tensors with different shapes, (3) passing Python objects instead of tensors. For (1), please define your @tf.function outside of the loop. For (2), @tf.function has experimental_relax_shapes=True option that relaxes argument shapes that can avoid unnecessary retracing. For (3), please refer to https://www.tensorflow.org/guide/function#controlling_retracing and https://www.tensorflow.org/api_docs/python/tf/function for  more details.
[CV 5/10] END classify=SVC(), classify__random_state=2021, project=Ivis(verbose=0), project__k=15;, score=(train=0.948, test=0.800) total time=   0.3s
WARNING:tensorflow:No training configuration found in the save file, so the model was *not* compiled. Compile it manually.
WARNING:tensorflow:No training configuration found in the save file, so the model was *not* compiled. Compile it manually.
[CV 6/10] END classify=SVC(), classify__random_state=2021, project=Ivis(verbose=0), project__k=15;, score=(train=0.970, test=0.800) total time=   0.4s
WARNING:tensorflow:No training configuration found in the save file, so the model was *not* compiled. Compile it manually.
WARNING:tensorflow:No training configuration found in the save file, so the model was *not* compiled. Compile it manually.
[CV 7/10] END classify=SVC(), classify__random_state=2021, project=Ivis(verbose=0), project__k=15;, score=(train=0.933, test=1.000) total time=   0.4s
WARNING:tensorflow:No training configuration found in the save file, so the model was *not* compiled. Compile it manually.
WARNING:tensorflow:No training configuration found in the save file, so the model was *not* compiled. Compile it manually.
[CV 8/10] END classify=SVC(), classify__random_state=2021, project=Ivis(verbose=0), project__k=15;, score=(train=0.919, test=0.933) total time=   0.4s
WARNING:tensorflow:No training configuration found in the save file, so the model was *not* compiled. Compile it manually.
WARNING:tensorflow:No training configuration found in the save file, so the model was *not* compiled. Compile it manually.
[CV 9/10] END classify=SVC(), classify__random_state=2021, project=Ivis(verbose=0), project__k=15;, score=(train=0.978, test=0.733) total time=   0.4s
WARNING:tensorflow:No training configuration found in the save file, so the model was *not* compiled. Compile it manually.
WARNING:tensorflow:No training configuration found in the save file, so the model was *not* compiled. Compile it manually.
[CV 10/10] END classify=SVC(), classify__random_state=2021, project=Ivis(verbose=0), project__k=15;, score=(train=0.867, test=0.400) total time=   0.3s
WARNING:tensorflow:Compiled the loaded model, but the compiled metrics have yet to be built. `model.compile_metrics` will be empty until you train or evaluate the model.
WARNING:tensorflow:Compiled the loaded model, but the compiled metrics have yet to be built. `model.compile_metrics` will be empty until you train or evaluate the model.
WARNING:tensorflow:Compiled the loaded model, but the compiled metrics have yet to be built. `model.compile_metrics` will be empty until you train or evaluate the model.
WARNING:tensorflow:Compiled the loaded model, but the compiled metrics have yet to be built. `model.compile_metrics` will be empty until you train or evaluate the model.
```

## Example without `sklearn.pipeline.Pipeline`

This example demonstrates that the proposed solution is working by means of a simpler script while also showing the aforementioned warnings. It is also executed successfully.

### Script

```
import ivis
import joblib

from sklearn import datasets, model_selection

print(f"Loading and splitting the Iris Flower data set...")
X, y = datasets.load_iris(return_X_y=True)
X_train, X_test, y_train, y_test = model_selection.train_test_split(X, y, test_size=0.33, random_state=42)

print(f"Projecting Iris Flower in two dimensions in the generated model...")
projector = ivis.Ivis(k=90, batch_size=90, verbose=0).fit(X_train, y_train)
X_train_pred = projector.transform(X_train)
X_test_pred = projector.transform(X_test)

file_name = "model.pkl"

print(f"Saving the generated model into {file_name}...")
joblib.dump(projector, file_name)

print(f"Loading the saved model in {file_name}...")
projector2 = joblib.load(file_name)

print(f"Projecting Iris Flower in two dimensions in the loaded model...")
X_train_pred2 = projector2.transform(X_train)
X_test_pred2 = projector2.transform(X_test)

print(f"Prediction comparison between generated and loaded models:")
print(f" |_ Are the train transforms of both models equal? {(X_train_pred == X_train_pred2).all()}")
print(f" |_ Are the test transforms of both models equal? {(X_test_pred == X_test_pred2).all()}")
```

### Log

```
Loading and splitting the Iris Flower data set...
Projecting Iris Flower in two dimensions in the generated model...
Saving the generated model into model.pkl...
WARNING:tensorflow:Compiled the loaded model, but the compiled metrics have yet to be built. `model.compile_metrics` will be empty until you train or evaluate the model.
WARNING:tensorflow:Compiled the loaded model, but the compiled metrics have yet to be built. `model.compile_metrics` will be empty until you train or evaluate the model.
Loading the saved model in model.pkl...
WARNING:tensorflow:No training configuration found in the save file, so the model was *not* compiled. Compile it manually.
WARNING:tensorflow:No training configuration found in the save file, so the model was *not* compiled. Compile it manually.
Projecting Iris Flower in two dimensions in the loaded model...
Prediction comparison between generated and loaded models:
 |_ Are the train transforms of both models equal? True
 |_ Are the test transforms of both models equal? True
```

# Additional comments

This pull request, if accepted, will make `Ivis` have two means of saving/loading models with two distinct implementations that would need to be maintained. In case there is no attachment to the existing implementation, one possibility worth contemplating is to deprecate the methodology applied in `Ivis.load_model()` and `Ivis.save_model()` and make these methods produce pickle files instead. Another alternative would be to deprecate these methods entirely and merely inform the user that `Ivis` can be pickled. On the other hand, if maintaining both implementations is justified, this paragraph can be disregarded.

Regarding the warnings: do you know how we could mitigate them? I guess `tensorflow` is instructing the user to use the `.compile()` method; however, since I am not familiar with `tensorflow`, I found it better to leave this up to you. I did try to silence this warning following a couple of different alternatives within `tensorflow`; however, this warning was unaffected.

Some small observations are worth making as well. The proposed `Ivis.__getstate__()` and `Ivis.__setstate__()` methods have some conditionals imposed to meet the expectations of `sklearn.base.clone()`, which is used in `sklearn.model_selection.GridSearchCV`. Additionally, no structural changes were made in `ivis/data/neighbour_retrieval/knn.py`. This file was just formatted by PyCharm to adhere to some PEP spacing conventions.